### PR TITLE
update version in __init__.py before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           VERSION=$(echo $GITHUB_REF | cut -d '/' -f 3)
           sed -i "s/version = \"0.0.0\"/version = \"${VERSION}\"/g" pyproject.toml
+          sed -i "s/__version__ = \"0.0.0\"/__version__ = \"${VERSION}\"/g" src/pyspark_dataframe_wrappers/__init__.py
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/src/pyspark_dataframe_wrappers/__init__.py
+++ b/src/pyspark_dataframe_wrappers/__init__.py
@@ -5,4 +5,4 @@
 """Python Package Template"""
 from __future__ import annotations
 
-__version__ = "0.0.2"
+__version__ = "0.0.0"


### PR DESCRIPTION
Couple things happening here: first -- sorry for not mobbing on this, but I'm using this as a quick test to get a developement environment sorted out on my new machine (which is noticeably NOT linux). Interestingly, the `sed` command here might actually not work on a mac... so that gives me a chance to show how I test things like this in `docker`
 
The mac version of my favorite docker shortcut:

``` shell
function rund() {
  docker run --interactive \
    --tty \
    --user root \
    --volume "$PWD":/$(basename "$PWD") \
    --workdir /$(basename "$PWD") \
    --entrypoint /bin/bash \
    "$@"
}
```
Usage `rund <container-image> [commands]` which will run the  specified docker container in an interactive mode, as the root user, using your current directory as a volume mount, which is also the working directory.  If you don't specify other commands, it just enters in on `/bin/bash`. 

So here's what that looks like on a shell:

```shell
brianberzins:~/code/src/github.com/brianberzins/pyspark-dataframe-wrappers(main)$ rund ubuntu   
root@199a9198850c:/pyspark-dataframe-wrappers# export VERSION=1.5.2
root@199a9198850c:/pyspark-dataframe-wrappers# sed -i "s/__version__ = \"0.0.0\"/__version__ = \"${VERSION}\"/g" src/pyspark_dataframe_wrappers/__init__.py
root@199a9198850c:/pyspark-dataframe-wrappers# grep version src/pyspark_dataframe_wrappers/__init__.py 
__version__ = "1.5.2"
```

Makes testing things between environments much easier. Otherwise, how long would I have spent trying to figure out why `sed` is different on my Mac?

```shell
brianberzins:~/code/src/github.com/brianberzins/pyspark-dataframe-wrappers(main)$ export VERSION=1.5.2
brianberzins:~/code/src/github.com/brianberzins/pyspark-dataframe-wrappers(main)$ sed -i "s/__version__ = \"0.0.0\"/__version__ = \"${VERSION}\"/g" src/pyspark_dataframe_wrappers/__init__.py
sed: 1: "src/pyspark_dataframe_w ...": bad flag in substitute command: 'a'
```

resolves #17 